### PR TITLE
librealsense: 1.12.1-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -7,5 +7,16 @@ release_platforms:
   - bionic
   - xenial
 repositories:
+  ros2_object_analytics:
+    release:
+      packages:
+      - object_analytics_launch
+      - object_analytics_msgs
+      - object_analytics_node
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
+      version: 0.3.0-0
+    status: maintained
 type: distribution
 version: 2

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -7,6 +7,13 @@ release_platforms:
   - bionic
   - xenial
 repositories:
+  librealsense:
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yechun1/librealsense-release.git
+      version: 1.12.1-0
+    status: maintained
   ros2_object_analytics:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `1.12.1-0`:

- upstream repository: https://github.com/yechun1/librealsense.git
- release repository: https://github.com/yechun1/librealsense-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
