### PR TITLE
librealsense: 1.12.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2331,7 +2331,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yechun1/librealsense-release.git
-      version: 1.12.1-0
+      version: 1.12.1-1
     source:
       type: git
       url: https://github.com/yechun1/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `1.12.1-1`:

- upstream repository: https://github.com/yechun1/librealsense.git
- release repository: https://github.com/yechun1/librealsense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.1-0`
