### PR TITLE
ros2_object_analytics: 0.4.0-2 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1017,6 +1017,17 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: bouncy
     status: developed
+  ros2_object_analytics:
+    release:
+      packages:
+      - object_analytics_launch
+      - object_analytics_msgs
+      - object_analytics_node
+      - object_analytics_rviz
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yechun1/ros2_object_analytics-release.git
+      version: 0.4.0-1
   ros2cli:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1027,7 +1027,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/yechun1/ros2_object_analytics-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_object_analytics` to `0.4.0-2`:

- upstream repository: https://github.com/intel/ros2_object_analytics.git
- release repository: https://github.com/yechun1/ros2_object_analytics-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.4.0-1`

## object_analytics_launch

```
* update maintainer
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* fix c++ code style issue
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #32 <https://github.com/intel/ros2_object_analytics/issues/32> from intel/fix_performance_issue
  Remove ncs launch code out of OA code
* Remove ncs launch code
  add ncs launch step in Readme.txt
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #20 <https://github.com/intel/ros2_object_analytics/issues/20> from intel/log_code
  add name in launch file
* add name in launch file
  so that log message will have package name displayed.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #17 <https://github.com/intel/ros2_object_analytics/issues/17> from intel/rviz_cpp
  ported image_publisher work on ros2 rviz
* ported image_publisher work on ros2 rviz
  enabled image_publisher on cpp and py, cpp pass test while py not work.
  image publisher used to display rectangle of tracked object on image viewer.
  this is full ros2 rviz support without ros1_bridge.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #16 <https://github.com/intel/ros2_object_analytics/issues/16> from intel/rviz_cpp
  add default rviz in launch file
* add default rviz in launch file
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #15 <https://github.com/intel/ros2_object_analytics/issues/15> from intel/rviz_cpp
  Rviz cpp
* add rviz launch file
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add CHANGELOG.rst
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Contributors: Chris Ye
```

## object_analytics_msgs

```
* update maintainer
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #23 <https://github.com/intel/ros2_object_analytics/issues/23> from intel/perf
  Merge detected object in localization and tracking
* Merge detected object in localization and tracking
  Merged detected object_name and probability in localization and tracking object,
  so that users could only subscribe localization or tracking, needn't sub detected object
  and needn't do message fileter again.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add CHANGELOG.rst
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Contributors: Chris Ye
```

## object_analytics_node

```
* update maintainer
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* remove unused cloud_segment parameter
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* fix c++ code style issue
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add ament_cppcheck
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #31 <https://github.com/intel/ros2_object_analytics/issues/31> from ahuizxc/new-segmentation-alg
  new segmentation algorithm, faster and more accurate
* fixed bugs to pass CI test
* fix format bug
* Merge pull request #32 <https://github.com/intel/ros2_object_analytics/issues/32> from intel/fix_performance_issue
  Remove ncs launch code out of OA code
* Remove ncs launch code
  add ncs launch step in Readme.txt
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* new segmentation algorithm, faster and more accurate
* Merge pull request #30 <https://github.com/intel/ros2_object_analytics/issues/30> from qingmingjie/test
  update unittest_trackingmanager.cpp
* update unittest_trackingmanager.cpp
* Merge pull request #24 <https://github.com/intel/ros2_object_analytics/issues/24> from qingmingjie/add_test
  add tracking test code
* Modify unittest_trackingmanager.cpp
* add tracking test code
* Merge pull request #23 <https://github.com/intel/ros2_object_analytics/issues/23> from intel/perf
  Merge detected object in localization and tracking
* Update unittest after add object in objects_in_boxes
  unnitest also need to update after added object_name and probility in ObjectInBox3D msgs.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge detected object in localization and tracking
  Merged detected object_name and probability in localization and tracking object,
  so that users could only subscribe localization or tracking, needn't sub detected object
  and needn't do message fileter again.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #22 <https://github.com/intel/ros2_object_analytics/issues/22> from intel/perf
  splite pointcloud2 to rgb and xyz
* splite pointcloud2 to rgb and xyz
  Currently localization using pcl segementation api which not required rgb,
  this patch splited Pointcloud2 to XYZ, reduced half size of PointCloud2 (from 9.83M reduce to 4.91M)
  imporved pointcloud2 sub-pub transport performance.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #17 <https://github.com/intel/ros2_object_analytics/issues/17> from intel/rviz_cpp
  ported image_publisher work on ros2 rviz
* optimize parameter to be passed by reference
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #14 <https://github.com/intel/ros2_object_analytics/issues/14> from intel/tracking_roi
  fix tracking roi not match objected roi
* fix tracking roi not match objected roi
  tracking will change objects roi because of size boundary.
  Backup objected roi before handle tracking, after tracking handled, restore objected roi,
  so that the roi of tracking and objected could match.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Revert "add CMakeLists"
  function not stable, revert first
  This reverts commit 0275614c16c0a7a2ba8612abdb665b11e397a951.
* Merge pull request #8 <https://github.com/intel/ros2_object_analytics/issues/8> from qingmingjie/add_test
  add test
* add CMakeLists
* add message_filters build_depend
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #4 <https://github.com/intel/ros2_object_analytics/issues/4> from intel/for_deb_build
  add class_loader dependence for deb package build
* add class_loader dependence for deb package build
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add cv_bridge dep in package.xml
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add CHANGELOG.rst
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Remove useless parameter to supress warning
  Signed-off-by: Peter Han <mailto:peter9606@gmail.com>
* Change class_loader to default branch
  Signed-off-by: Peter Han <mailto:peter.han@intel.com>
* Contributors: Chris Ye, Peter Han, ahuizxc, qingmingjie, yechun1
```

## object_analytics_rviz

```
* update maintainer
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* fix c++ code style issue
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* add ament_cppcheck
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #29 <https://github.com/intel/ros2_object_analytics/issues/29> from ahuizxc/multi-obj-in-rviz
  support showing multi objects localization marks in RVIZ
* deleted these two lines and changed the clear objects code
* support showing multi objects localization marks in RVIZ
* Merge pull request #23 <https://github.com/intel/ros2_object_analytics/issues/23> from intel/perf
  Merge detected object in localization and tracking
* Merge detected object in localization and tracking
  Merged detected object_name and probability in localization and tracking object,
  so that users could only subscribe localization or tracking, needn't sub detected object
  and needn't do message fileter again.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Revert "moving object rectangle with correct position"
  ros2_movidius_ncs have fixed roi issue, revert the patch.
  This reverts commit 17a1120a37905e2fe619225f89f0903e7fb90f97.
* Merge pull request #18 <https://github.com/intel/ros2_object_analytics/issues/18> from intel/rviz_cpp
  fix rviz line draw malposition issue
* fix rviz line draw malposition issue
  set marker.pos.position is not correct, the value should be zero, just remove it and it will use default zero value.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* moving object rectangle with correct position
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #17 <https://github.com/intel/ros2_object_analytics/issues/17> from intel/rviz_cpp
  ported image_publisher work on ros2 rviz
* optimize parameter to be passed by reference
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* reduce scope of variable
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* ported image_publisher work on ros2 rviz
  enabled image_publisher on cpp and py, cpp pass test while py not work.
  image publisher used to display rectangle of tracked object on image viewer.
  this is full ros2 rviz support without ros1_bridge.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Merge pull request #15 <https://github.com/intel/ros2_object_analytics/issues/15> from intel/rviz_cpp
  Rviz cpp
* Initialize object_analytics_rviz for ros2
  rewrite marker_publisher with cpp from python.
  subscibe detection/localization/tracking topic and publish box_3d_markers,
  to display object analytics result on rviz.
  Signed-off-by: Chris Ye <mailto:chris.ye@intel.com>
* Contributors: Chris Ye, ahuizxc
```
