### PR TITLE
object_msgs: 0.3.0-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -660,6 +660,22 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  object_msgs:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: 0.3.0
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.3.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: 0.3.0
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/ros2-gbp/ros2_object_msgs-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`
