### PR TITLE
librealsense: 2.16.5-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -496,7 +496,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/yechun1/librealsense-release.git
-      version: 2.16.5-0
+      version: 2.16.5-1
     source:
       type: git
       url: https://github.com/yechun1/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `2.16.5-1`:

- upstream repository: https://github.com/yechun1/librealsense.git
- release repository: https://github.com/yechun1/librealsense-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.16.5-0`
