### PR TITLE
object_msgs: 0.3.0-3 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -595,7 +595,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/yechun1/ros2_object_msgs-release.git
-      version: 0.3.0-1
+      version: 0.3.0-3
     source:
       type: git
       url: https://github.com/intel/ros2_object_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.3.0-3`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/yechun1/ros2_object_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.0-1`
